### PR TITLE
.github/Funding.yml: Fix patreon link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,7 +1,7 @@
 # These are supported funding model platforms
 
 github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
-patreon: ArchLabs Linux
+patreon: archlabslinux
 open_collective: # Replace with a single Open Collective username
 ko_fi: # Replace with a single Ko-fi username
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel


### PR DESCRIPTION
- There was a space between the patreon link which was causing a 404 error

--> Remove the extra space to fix that.

- The characters in the patreon link were both lowercase and as well as upper-case, which doesnt matter because patreon do not treat urls as case-sensitive

--> But still make them all to lowercase, because that is what the correct url is.
